### PR TITLE
Race condition fix

### DIFF
--- a/Apps/DeviceTimeActiveTracker_Child
+++ b/Apps/DeviceTimeActiveTracker_Child
@@ -9,6 +9,7 @@
 *
 *	Change Revision History:  
 *   Ver		Date:		Who:		What:
+*   1.5.3	2025-03-10	basilisk487	Pull request: Fixes a race condition when multiple devices send updates very close to each other.
 *   1.5.2	2024-12-17	kampto    	Fixed Removing device bug. Changed Battery threshold. Add last Battery total days tracker (1.5.0). Battery page Note. Fix Bat last report issue(1.5.2)
 *   1.4.7	2023-08-24	kampto    	Add Battery level tracking and options. Added Last Battery report date. Threshold 50%. Add Motion and Humidty sensor capability
 *   1.3.4	2023-06-28	kampto    	Add Max on time variable link. Restructer Resets code. Moved reset when on to table check box.
@@ -31,7 +32,7 @@ import java.text.SimpleDateFormat
 
 def setVersion() {
     state.name = "Device Tracker: Times, Levels, Last Active, and Counts (Child)"
-	state.version = "1.5.2"
+	state.version = "1.5.3"
     }
 
 definition (
@@ -43,6 +44,7 @@ definition (
 	iconX2Url: "",
     importUrl: "https://raw.githubusercontent.com/kampto/Hubitat/main/Apps/DeviceTimeActiveTracker_Child",
     documentationLink: "https://community.hubitat.com/t/app-device-active-tracker-multiple-device-on-off-times-on-counts-notifier-battery-levels-with-variables-access/102896"
+	singleThreaded: true
 	)
 
 preferences { page(name: "mainPage") }


### PR DESCRIPTION
Application's state is not thread-safe, so when multiple devices that belong to the same child app are sending updates at the same time, they step on each other's toes, overwriting the application's state. Designating the app as single-threaded makes sure all events are processed sequentially and state remains consistent for every run.